### PR TITLE
Fix/header images

### DIFF
--- a/events.html
+++ b/events.html
@@ -141,7 +141,7 @@
   </footer>
   <!-- Optional JavaScript -->
   <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-  <script src="https://code.jquery.com/jquery-3.3.1.min.js"</script>
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
     integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous">
   </script>

--- a/index.html
+++ b/index.html
@@ -58,16 +58,16 @@
   <div class="jumbotron jumbotron-fluid container-fluid" style="padding-top: 10px; padding-bottom: 10px; margin-top: 5px; margin-bottom: 5px;">
     <div class="container">
       <div class="row">
-        <div class="col-md-8" style="vertical-align: middle">
+        <div class="col-12 col-md-8" style="vertical-align: middle">
           <h1 class="display-4"><strong>Society of Physics Students</strong></h1>
           <h4 class="lead"><strong>Lawrence Technological University</strong></h4>
         </div>
-        <div class="col-md-2">
+        <div class="col-3 offset-sm-2 col-md-2 offset-md-0">
           <a href="https://www.spsnational.org/">
             <img class="img-fluid img-responsive" src="assets/SPS_Logo_Border.png" style="width: 100%;">
           </a>
         </div>
-        <div class="col-md-2">
+        <div class="col-3 offset-sm-2 col-md-2 offset-md-0">
           <a href="https://www.aps.org/programs/innovation/fund/idea.cfm">
             <img class="img-fluid img-responsive" src="assets/APS_IDEA_Logo.png" style="width: 100%;">
           </a>


### PR DESCRIPTION
This pull request will add responsive sizing for the logos on the homepage banner.

Steps to test:
- In a local browser, open the homepage.
- Right click on the page, and click "Inspect" to open devtools.
- Toggle the device toolbar by clicking the icon of mobile devices in the upper left corder of the devtools.
- Using the dropdown at the top of the screen, experiment with different viewport sizes.
- See that the logos resize by breakpoint to more appropriate sizes.